### PR TITLE
Analytics events

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,3 @@
+interface Window {
+  gtag: any
+}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -24,4 +24,8 @@ test('renders App component', () => {
   render(<App />)
   const linkElement = screen.getByText(GAME_TITLE)
   expect(linkElement).toBeInTheDocument()
+
+  expect(window.gtag).toHaveBeenCalledWith('event', 'sign_up', {
+    method: `Anonymous`,
+  })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,6 +56,7 @@ import {
   solution,
   solutionGameDate,
   solutionIndex,
+  solutionName,
 } from './lib/quotes'
 import { addStatsForCompletedGame, loadStats } from './lib/stats'
 import { CharStatus } from './lib/statuses'
@@ -201,21 +202,33 @@ function App() {
 
   const handleDarkMode = (isDark: boolean) => {
     setIsDarkMode(isDark)
-    localStorage.setItem('theme', isDark ? 'dark' : 'light')
+    const colorMode = isDark ? 'dark' : 'light'
+    localStorage.setItem('theme', colorMode)
+    window.gtag('event', 'unlock_achievement', {
+      achievement_id: `choose_${colorMode}_mode`,
+    })
   }
 
   const handleHardMode = (isHard: boolean) => {
     if (guesses.length === 0 || localStorage.getItem('gameMode') === 'hard') {
       setIsHardMode(isHard)
-      localStorage.setItem('gameMode', isHard ? 'hard' : 'normal')
+      const gameMode = isHard ? 'hard' : 'normal'
+      localStorage.setItem('gameMode', gameMode)
+      window.gtag('event', 'unlock_achievement', {
+        achievement_id: `choose_${gameMode}_mode`,
+      })
     } else {
       showErrorAlert(HARD_MODE_ALERT_MESSAGE)
     }
   }
 
   const handleHighContrastMode = (isHighContrast: boolean) => {
+    const colorMode = isHighContrast ? 'high_contrast' : 'normal_contrast'
     setIsHighContrastMode(isHighContrast)
     setStoredIsHighContrastMode(isHighContrast)
+    window.gtag('event', 'unlock_achievement', {
+      achievement_id: `choose_${colorMode}`,
+    })
   }
 
   useEffect(() => {
@@ -310,7 +323,13 @@ function App() {
         debug('All the letters have been guessed', guesses)
         if (isLatestGame) {
           // TODO this is causing the stats to be multiples of page reloads
-          setStats(addStatsForCompletedGame(stats, incorrectGuesses.length))
+          setStats(
+            addStatsForCompletedGame(
+              solutionName,
+              stats,
+              incorrectGuesses.length
+            )
+          )
         }
         setIsGameWon(true)
       }
@@ -322,7 +341,13 @@ function App() {
           MAX_CHALLENGES
         )
         if (isLatestGame) {
-          setStats(addStatsForCompletedGame(stats, incorrectGuesses.length + 1))
+          setStats(
+            addStatsForCompletedGame(
+              solutionName,
+              stats,
+              incorrectGuesses.length + 1
+            )
+          )
         }
         setIsGameLost(true)
         showErrorAlert(CORRECT_WORD_MESSAGE(solution), {
@@ -420,10 +445,21 @@ function App() {
       hintCount++
       hint = generateCryptogramHint(cipher, solution, solutionIndex + hintCount)
     }
-    if (hint && hint.keyLetter && hint.originalLetter) {
+    if (
+      hint &&
+      hint.keyLetter &&
+      hint.originalLetter &&
+      currentCipher[hint.keyLetter].guesses[0] !== hint.originalLetter
+    ) {
       onChar(hint?.originalLetter, hint?.keyLetter)
+      window.gtag('event', 'unlock_achievement', {
+        achievement_id: 'use_hint',
+      })
     }
     if (hintCount >= 10) {
+      window.gtag('event', 'unlock_achievement', {
+        achievement_id: 'exhausted_hints',
+      })
       showErrorAlert('No more hints available.', {
         persist: false,
       })
@@ -516,6 +552,9 @@ function App() {
               })
             }
             handleMigrateStatsButton={() => {
+              window.gtag('event', 'unlock_achievement', {
+                achievement_id: 'click_transfer_stats',
+              })
               setIsStatsModalOpen(false)
               setIsMigrateStatsModalOpen(true)
             }}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -88,6 +88,8 @@ solution
       solutionLetters.push(letter)
     }
   })
+let userHasGuessedALetter = false
+let userHasIncorrectlyGuessedALetter = false
 
 function App() {
   const isLatestGame = getIsLatestGame()
@@ -292,6 +294,11 @@ function App() {
         if (input === updatedCipher[label].decrypted) {
           status = 'correct'
           updatedCipher[label].status = status
+          if (!userHasGuessedALetter) {
+            window.gtag('event', 'unlock_achievement', {
+              achievement_id: 'make_correct_guess',
+            })
+          }
         } else if (solutionLetters.includes(input)) {
           status = 'present'
           updatedCipher[label].status = status
@@ -301,6 +308,11 @@ function App() {
         }
         setGuesses([...guesses, { input, status }])
         if (input !== updatedCipher[label].decrypted) {
+          if (!userHasIncorrectlyGuessedALetter) {
+            window.gtag('event', 'unlock_achievement', {
+              achievement_id: 'make_incorrect_guess',
+            })
+          }
           debug('This was an incorrect guess', input)
           setIncorrectGuesses([...incorrectGuesses, { input, status, label }])
           setIsRevealing(true)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -295,6 +295,7 @@ function App() {
           status = 'correct'
           updatedCipher[label].status = status
           if (!userHasGuessedALetter) {
+            userHasGuessedALetter = true
             window.gtag('event', 'unlock_achievement', {
               achievement_id: 'make_correct_guess',
             })
@@ -309,6 +310,7 @@ function App() {
         setGuesses([...guesses, { input, status }])
         if (input !== updatedCipher[label].decrypted) {
           if (!userHasIncorrectlyGuessedALetter) {
+            userHasIncorrectlyGuessedALetter = true
             window.gtag('event', 'unlock_achievement', {
               achievement_id: 'make_incorrect_guess',
             })

--- a/src/components/alphabet/Letter.tsx
+++ b/src/components/alphabet/Letter.tsx
@@ -9,6 +9,9 @@ import { CharStatus } from '../../lib/statuses'
 const isPunctuation = (randomKey: string) => {
   return /\W/.test(randomKey)
 }
+
+let userHasInteractedWithLetter = false
+
 type Props = {
   children?: ReactNode
   alphabetLine: string | null
@@ -68,6 +71,12 @@ export const Letter = ({
   }
 
   const handleClick: React.MouseEventHandler<HTMLButtonElement> = (event) => {
+    if (!userHasInteractedWithLetter) {
+      userHasInteractedWithLetter = true
+      window.gtag('event', 'unlock_achievement', {
+        achievement_id: 'click_alphabet_letter',
+      })
+    }
     const label = (event?.target as HTMLButtonElement)?.ariaLabel || ''
 
     onClick(randomKey, label)

--- a/src/components/cryptogram/Cell.tsx
+++ b/src/components/cryptogram/Cell.tsx
@@ -19,6 +19,8 @@ type Props = {
   onClick: (input: string, ariaLabel: string) => void
 }
 
+let userHasInteractedWithCell = false
+
 export const Cell = ({
   encryptedValue,
   decryptedValue,
@@ -78,6 +80,12 @@ export const Cell = ({
   const hiddenInputRef: RefObject<HTMLInputElement> = createRef()
 
   const cellOnClick: React.MouseEventHandler<HTMLDivElement> = (event) => {
+    if (!userHasInteractedWithCell) {
+      userHasInteractedWithCell = true
+      window.gtag('event', 'unlock_achievement', {
+        achievement_id: 'click_cryptogram_cell',
+      })
+    }
     const label = (event?.target as HTMLDivElement)?.ariaLabel || ''
 
     onClick('', label)

--- a/src/components/modals/DatePickerModal.tsx
+++ b/src/components/modals/DatePickerModal.tsx
@@ -126,7 +126,12 @@ export const DatePickerModal = ({
           disabled={!isValidGameDate(getToday())}
           className="mt-2 inline-flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-center text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:border-gray-200 disabled:bg-gray-500 disabled:bg-white disabled:text-gray-900
           disabled:focus:outline-none disabled:dark:border-gray-600 disabled:dark:bg-gray-800 disabled:dark:text-gray-400 sm:text-base sm:text-base"
-          onClick={() => handleSelectDate(getToday())}
+          onClick={() => {
+            window.gtag('event', 'unlock_achievement', {
+              achievement_id: 'choose_todays_game',
+            })
+            handleSelectDate(getToday())
+          }}
         >
           {DATEPICKER_CHOOSE_TEXT} {DATEPICKER_TODAY_TEXT}
         </button>
@@ -134,7 +139,12 @@ export const DatePickerModal = ({
           type="button"
           className="mt-2 inline-flex w-full items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-center text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 "
           disabled={selectedDate >= getToday()}
-          onClick={() => handleSelectDate(selectedDate)}
+          onClick={() => {
+            window.gtag('event', 'unlock_achievement', {
+              achievement_id: 'choose_archived_game',
+            })
+            handleSelectDate(selectedDate)
+          }}
         >
           {DATEPICKER_CHOOSE_TEXT}
           <br />

--- a/src/components/modals/InfoModal.tsx
+++ b/src/components/modals/InfoModal.tsx
@@ -9,10 +9,21 @@ type Props = {
 const onClick = (input: string, ariaLabel: string) => {
   alert(`You clicked on ${ariaLabel}`)
 }
+let firstTutorial = true
 
 export const InfoModal = ({ isOpen, handleClose }: Props) => {
+  if (isOpen && firstTutorial) {
+    firstTutorial = false
+    window.gtag('event', 'tutorial_begin')
+  }
+
+  function onCloseClick() {
+    window.gtag('event', 'tutorial_complete')
+    return handleClose()
+  }
+
   return (
-    <BaseModal title="How to play" isOpen={isOpen} handleClose={handleClose}>
+    <BaseModal title="How to play" isOpen={isOpen} handleClose={onCloseClick}>
       <p className="text-sm text-gray-500 dark:text-gray-300">
         Guess the letter. After each guess, the color of the tile will change to
         show how close your guess was to the word.

--- a/src/components/modals/SettingsToggle.tsx
+++ b/src/components/modals/SettingsToggle.tsx
@@ -13,6 +13,7 @@ export const SettingsToggle = ({
   handleFlag,
   description,
 }: Props) => {
+  const setting = settingName.toLowerCase().replace(' ', '_')
   const toggleHolder = classnames(
     'w-14 h-8 flex shrink-0 items-center bg-gray-300 rounded-full p-1 duration-300 ease-in-out cursor-pointer',
     {
@@ -30,7 +31,7 @@ export const SettingsToggle = ({
     <>
       <div className="flex justify-between gap-4 py-3">
         <div className="mt-2 text-left text-gray-500 dark:text-gray-300">
-          <p className="leading-none">{settingName}</p>
+          <p className="leading-none">{setting}</p>
           {description && (
             <p className="mt-1 text-xs text-gray-500 dark:text-gray-300">
               {description}
@@ -40,7 +41,12 @@ export const SettingsToggle = ({
         <div
           aria-label={settingName}
           className={toggleHolder}
-          onClick={() => handleFlag(!flag)}
+          onClick={() => {
+            window.gtag('event', 'unlock_achievement', {
+              achievement_id: `toggle_${setting}`,
+            })
+            handleFlag(!flag)
+          }}
         >
           <div className={toggleButton} />
         </div>

--- a/src/components/modals/SettingsToggle.tsx
+++ b/src/components/modals/SettingsToggle.tsx
@@ -13,7 +13,6 @@ export const SettingsToggle = ({
   handleFlag,
   description,
 }: Props) => {
-  const setting = settingName.toLowerCase().replace(' ', '_')
   const toggleHolder = classnames(
     'w-14 h-8 flex shrink-0 items-center bg-gray-300 rounded-full p-1 duration-300 ease-in-out cursor-pointer',
     {
@@ -31,7 +30,7 @@ export const SettingsToggle = ({
     <>
       <div className="flex justify-between gap-4 py-3">
         <div className="mt-2 text-left text-gray-500 dark:text-gray-300">
-          <p className="leading-none">{setting}</p>
+          <p className="leading-none">{settingName}</p>
           {description && (
             <p className="mt-1 text-xs text-gray-500 dark:text-gray-300">
               {description}
@@ -41,12 +40,7 @@ export const SettingsToggle = ({
         <div
           aria-label={settingName}
           className={toggleHolder}
-          onClick={() => {
-            window.gtag('event', 'unlock_achievement', {
-              achievement_id: `toggle_${setting}`,
-            })
-            handleFlag(!flag)
-          }}
+          onClick={() => handleFlag(!flag)}
         >
           <div className={toggleButton} />
         </div>

--- a/src/components/modals/ShareMessageModal.tsx
+++ b/src/components/modals/ShareMessageModal.tsx
@@ -54,7 +54,7 @@ export const ShareMessageModal = ({ isOpen, handleClose }: Props) => {
 
   const handleSaveButton = () => {
     const textarea = document.getElementById(
-      'immigration-code'
+      'share-message'
     ) as HTMLInputElement
     window.gtag('event', 'unlock_achievement', {
       achievement_id: 'share_encrypted_message',
@@ -96,7 +96,7 @@ export const ShareMessageModal = ({ isOpen, handleClose }: Props) => {
         </label>
         <textarea
           onChange={(e) => handleImmigrationCodeChange(e)}
-          id="immigration-code"
+          id="share-message"
           rows={8}
           className="block w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500"
         ></textarea>

--- a/src/components/modals/ShareMessageModal.tsx
+++ b/src/components/modals/ShareMessageModal.tsx
@@ -56,6 +56,9 @@ export const ShareMessageModal = ({ isOpen, handleClose }: Props) => {
     const textarea = document.getElementById(
       'immigration-code'
     ) as HTMLInputElement
+    window.gtag('event', 'unlock_achievement', {
+      achievement_id: 'share_encrypted_message',
+    })
     if (
       textarea &&
       window.confirm(
@@ -71,6 +74,9 @@ export const ShareMessageModal = ({ isOpen, handleClose }: Props) => {
 
       const code = btoa(JSON.stringify(state))
       console.log('code', code)
+      window.gtag('event', 'unlock_achievement', {
+        achievement_id: 'open_shared_encrypted_message',
+      })
       window.location.replace(`?code=${code}`)
     }
   }

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -36,7 +36,7 @@ export const Navbar = ({
             className="h-6 w-6 cursor-pointer dark:stroke-white"
             onClick={() => {
               window.gtag('event', 'unlock_achievement', {
-                achievement_id: 'click_open_info_modal',
+                achievement_id: 'open_info_modal',
               })
               setIsInfoModalOpen(true)
             }}
@@ -48,7 +48,7 @@ export const Navbar = ({
               className="ml-3 h-6 w-6 cursor-pointer dark:stroke-white"
               onClick={() => {
                 window.gtag('event', 'unlock_achievement', {
-                  achievement_id: 'click_open_archived_games',
+                  achievement_id: 'open_archived_games',
                 })
                 setIsDatePickerModalOpen(true)
               }}
@@ -91,7 +91,7 @@ export const Navbar = ({
             className="mr-3 h-6 w-6 cursor-pointer dark:stroke-white"
             onClick={() => {
               window.gtag('event', 'unlock_achievement', {
-                achievement_id: 'click_open_stats',
+                achievement_id: 'open_stats',
               })
               setIsStatsModalOpen(true)
             }}
@@ -102,7 +102,7 @@ export const Navbar = ({
             className="h-6 w-6 cursor-pointer dark:stroke-white"
             onClick={() => {
               window.gtag('event', 'unlock_achievement', {
-                achievement_id: 'click_open_settings',
+                achievement_id: 'open_settings',
               })
               setIsSettingsModalOpen(true)
             }}

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -34,14 +34,24 @@ export const Navbar = ({
           <InformationCircleIcon
             aria-label="Open Info Modal"
             className="h-6 w-6 cursor-pointer dark:stroke-white"
-            onClick={() => setIsInfoModalOpen(true)}
+            onClick={() => {
+              window.gtag('event', 'unlock_achievement', {
+                achievement_id: 'click_open_info_modal',
+              })
+              setIsInfoModalOpen(true)
+            }}
             title="Show how to play"
           />
           {ENABLE_ARCHIVED_GAMES && (
             <CalendarIcon
               aria-label="Open Archived Games"
               className="ml-3 h-6 w-6 cursor-pointer dark:stroke-white"
-              onClick={() => setIsDatePickerModalOpen(true)}
+              onClick={() => {
+                window.gtag('event', 'unlock_achievement', {
+                  achievement_id: 'click_open_archived_games',
+                })
+                setIsDatePickerModalOpen(true)
+              }}
             />
           )}
         </div>
@@ -55,27 +65,47 @@ export const Navbar = ({
           <ChatBubbleOvalLeftIcon
             aria-label="Send an encrypted message"
             className="mr-3 h-6 w-6 cursor-pointer dark:stroke-white"
-            onClick={() => setIsSendMessageModalOpen(true)}
+            onClick={() => {
+              window.gtag('event', 'unlock_achievement', {
+                achievement_id: 'click_send_a_message',
+              })
+              setIsSendMessageModalOpen(true)
+            }}
             title="Click to write an encrypted message"
           />
 
           <PuzzlePieceIcon
             aria-label="Show Hint"
             className="mr-3 h-6 w-6 cursor-pointer dark:stroke-white"
-            onClick={() => setHint(true)}
+            onClick={() => {
+              window.gtag('event', 'unlock_achievement', {
+                achievement_id: 'click_show_hint',
+              })
+              setHint(true)
+            }}
             title="Click to insert the hint"
           />
 
           <ChartBarIcon
             aria-label="Open Stats"
             className="mr-3 h-6 w-6 cursor-pointer dark:stroke-white"
-            onClick={() => setIsStatsModalOpen(true)}
+            onClick={() => {
+              window.gtag('event', 'unlock_achievement', {
+                achievement_id: 'click_open_stats',
+              })
+              setIsStatsModalOpen(true)
+            }}
             title="Show stats"
           />
           <CogIcon
             aria-label="Open Settings"
             className="h-6 w-6 cursor-pointer dark:stroke-white"
-            onClick={() => setIsSettingsModalOpen(true)}
+            onClick={() => {
+              window.gtag('event', 'unlock_achievement', {
+                achievement_id: 'click_open_settings',
+              })
+              setIsSettingsModalOpen(true)
+            }}
             title="Open Settings"
           />
         </div>

--- a/src/components/stats/EmigratePanel.tsx
+++ b/src/components/stats/EmigratePanel.tsx
@@ -21,6 +21,9 @@ export const EmigratePanel = () => {
   const emigrationCode = encrypt(JSON.stringify(migrationStats))
 
   const copyEmigrationCodeToClipboard = () => {
+    window.gtag('event', 'unlock_achievement', {
+      achievement_id: 'exported_stats',
+    })
     copyTextToClipboard(emigrationCode)
     setCopyButtonText('Copied!')
     setIsCopyButtonEnabled(false)

--- a/src/components/stats/ImmigratePanel.tsx
+++ b/src/components/stats/ImmigratePanel.tsx
@@ -52,6 +52,9 @@ export const ImmigratePanel = () => {
     const textarea = document.getElementById(
       'immigration-code'
     ) as HTMLInputElement
+    window.gtag('event', 'unlock_achievement', {
+      achievement_id: 'click_import_stats',
+    })
     if (
       textarea &&
       window.confirm(
@@ -70,6 +73,9 @@ export const ImmigratePanel = () => {
       if (migrationStats.statistics) {
         saveStatsToLocalStorage(migrationStats.statistics)
       }
+      window.gtag('event', 'unlock_achievement', {
+        achievement_id: 'imported_stats',
+      })
 
       alert('The site will now reload.')
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,10 @@ ReactDOM.render(
   document.getElementById('root')
 )
 
+window.gtag('event', 'login', {
+  method: 'Anonymous',
+})
+
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals

--- a/src/lib/localStorage.ts
+++ b/src/lib/localStorage.ts
@@ -55,12 +55,12 @@ declare global {
 let firstGame = true
 export const loadStatsFromLocalStorage = () => {
   const stats = localStorage.getItem(gameStatKey)
-  // if (!stats && firstGame) {
-  //   firstGame = false
-  //   window.gtag('event', 'level_start', {
-  //     level_name: 'Start first game',
-  //   })
-  // }
+  if (!stats && firstGame) {
+    firstGame = false
+    window.gtag('event', 'sign_up', {
+      method: 'Anonymous',
+    })
+  }
   return stats ? (JSON.parse(stats) as GameStats) : null
 }
 

--- a/src/lib/localStorage.ts
+++ b/src/lib/localStorage.ts
@@ -46,8 +46,21 @@ export const saveStatsToLocalStorage = (gameStats: GameStats) => {
   localStorage.setItem(gameStatKey, JSON.stringify(gameStats))
 }
 
+declare global {
+  interface Window {
+    gtag: any
+  }
+}
+
+let firstGame = true
 export const loadStatsFromLocalStorage = () => {
   const stats = localStorage.getItem(gameStatKey)
+  // if (!stats && firstGame) {
+  //   firstGame = false
+  //   window.gtag('event', 'level_start', {
+  //     level_name: 'Start first game',
+  //   })
+  // }
   return stats ? (JSON.parse(stats) as GameStats) : null
 }
 

--- a/src/lib/quotes.ts
+++ b/src/lib/quotes.ts
@@ -136,11 +136,17 @@ export const getSolution = (gameDate: Date) => {
   const quoteOfTheDay = gameFromQueryParams.solution
     ? gameFromQueryParams.solution
     : getQuoteOfDay(index)
+
+  const solutionName = `${index} ${quoteOfTheDay}`.slice(0, 50)
+  window.gtag('event', 'level_start', {
+    level_name: `Cryptogram ${solutionName}`,
+  })
   return {
     message: gameFromQueryParams.message ? gameFromQueryParams.message : '',
     solution: quoteOfTheDay,
     solutionGameDate: gameDate,
     solutionIndex: index,
+    solutionName,
     tomorrow: nextGameDate.valueOf(),
   }
 }
@@ -204,6 +210,9 @@ export const loadGameStateFromQueryParam = (
       : emptyGame
     if (state.solution) {
       console.log('Loaded a game from query params', state)
+      window.gtag('event', 'unlock_achievement', {
+        achievement_id: 'open_shared_message',
+      })
     }
     return state
   } catch (err) {
@@ -212,5 +221,11 @@ export const loadGameStateFromQueryParam = (
   return emptyGame
 }
 
-export const { message, solution, solutionGameDate, solutionIndex, tomorrow } =
-  getSolution(getGameDate())
+export const {
+  message,
+  solution,
+  solutionGameDate,
+  solutionIndex,
+  solutionName,
+  tomorrow,
+} = getSolution(getGameDate())

--- a/src/lib/quotes.ts
+++ b/src/lib/quotes.ts
@@ -211,7 +211,7 @@ export const loadGameStateFromQueryParam = (
     if (state.solution) {
       console.log('Loaded a game from query params', state)
       window.gtag('event', 'unlock_achievement', {
-        achievement_id: 'open_shared_message',
+        achievement_id: 'open_shared_encrypted_message',
       })
     }
     return state

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -35,6 +35,11 @@ export const shareStatus = (
     if (attemptShare(shareData)) {
       navigator.share(shareData)
       shareSuccess = true
+      window.gtag('event', 'share', {
+        method: 'Navigator Share API',
+        content_type: 'text',
+        item_id: `${message} ${solutionIndex}`,
+      })
     }
   } catch (error) {
     shareSuccess = false
@@ -45,8 +50,18 @@ export const shareStatus = (
       if (navigator.clipboard) {
         navigator.clipboard
           .writeText(textToShare)
-          .then(handleShareToClipboard)
-          .catch(handleShareFailure)
+          .then(() => {
+            window.gtag('event', 'share', {
+              method: 'Navigator Clipboard API',
+              content_type: 'text',
+              item_id: `${message} ${solutionIndex}`,
+            })
+            handleShareToClipboard()
+          })
+          .catch(() => {
+            // TODO capture errors in gtag
+            handleShareFailure()
+          })
       } else {
         handleShareFailure()
       }

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -8,6 +8,7 @@ import {
 // In stats array elements 0-5 are successes in 1-6 trys
 
 export const addStatsForCompletedGame = (
+  gameName: string,
   gameStats: GameStats,
   count: number
 ) => {
@@ -15,14 +16,31 @@ export const addStatsForCompletedGame = (
   const stats = { ...gameStats }
 
   stats.totalGames += 1
+  window.gtag('event', 'level_up', {
+    level: stats.totalGames,
+    character: "Clueright's Cryptogram",
+  })
+  window.gtag('event', 'post_score', {
+    score: count,
+    level: stats.totalGames,
+    character: "Clueright's Cryptogram",
+  })
 
   if (count >= MAX_CHALLENGES) {
     // A fail situation
     stats.currentStreak = 0
     stats.gamesFailed += 1
+    window.gtag('event', 'level_end', {
+      level_name: `Cryptogram ${gameName}`,
+      success: false,
+    })
   } else {
     stats.winDistribution[count] += 1
     stats.currentStreak += 1
+    window.gtag('event', 'level_end', {
+      level_name: `Cryptogram ${gameName}`,
+      success: true,
+    })
 
     if (stats.bestStreak < stats.currentStreak) {
       stats.bestStreak = stats.currentStreak

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,3 +3,5 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom'
+
+global.window.gtag = jest.fn()

--- a/tests/analytics.spec.ts
+++ b/tests/analytics.spec.ts
@@ -85,13 +85,12 @@ test.describe('cryptogram tests', () => {
     console.log('gameEvents', gameEvents)
 
     expect(gameEvents).toEqual([
-      'unlock_achievement: open_shared_message',
+      'unlock_achievement: open_shared_encrypted_message',
       'level_start: Cryptogram 794 hi',
       'sign_up: Anonymous',
       'login: Anonymous',
       'unlock_achievement: click_alphabet_letter',
       'unlock_achievement: make_incorrect_guess',
-      'unlock_achievement: make_correct_guess',
       'unlock_achievement: make_correct_guess',
       'level_up: 1',
       'post_score: 1',

--- a/tests/analytics.spec.ts
+++ b/tests/analytics.spec.ts
@@ -63,7 +63,7 @@ test.describe('cryptogram tests', () => {
     //  get window.dataLayer and check events
     await page.waitForTimeout(300)
     const dataLayer = await page.evaluate(() => window.dataLayer)
-    console.log('dataLayer', dataLayer)
+    // console.log('dataLayer', dataLayer)
     const events = dataLayer
       .filter((e) => !!e.event)
       .map((event) => event.event)

--- a/tests/analytics.spec.ts
+++ b/tests/analytics.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('cryptogram tests', () => {
+  test('should send game events to google analytics', async ({ page }) => {
+    const path =
+      '/?code=eyJndWVzc2VzIjpbXSwiaW5kZXgiOjc5NCwibWVzc2FnZSI6IkFuIGVuY3J5cHRlZCBtZXNzYWdlIiwic29sdXRpb24iOiJoaSJ9'
+
+    await page.goto(path)
+    page.once('dialog', (dialog) => {
+      console.log(`Dialog message: ${dialog.message()}`)
+      dialog.dismiss().catch(() => {})
+    })
+    await page.getByLabel('How to play').getByText('P', { exact: true }).click()
+    await page.getByLabel('How to play').getByRole('button').click()
+
+    await page.getByLabel('Open Info Modal').click()
+    await page.getByLabel('How to play').getByRole('button').click()
+
+    await page.getByLabel('Send an encrypted message').click()
+    await page.locator('#share-message').click()
+    await page.locator('#share-message').fill('hi')
+    page.on('dialog', async (dialog) => {
+      console.log(dialog.message())
+      await dialog.accept()
+    })
+    await page.getByRole('button', { name: 'Save' }).click()
+
+    await page.getByRole('button', { name: 'R' }).click()
+    await page.keyboard.type('o')
+    expect(page.getByRole('button', { name: 'R' })).toHaveText('O')
+
+    await page.getByRole('button', { name: 'R' }).click()
+    await page.keyboard.type('i')
+    expect(page.getByRole('button', { name: 'R' })).toHaveText('I')
+
+    await page.getByRole('button', { name: 'S' }).click()
+    await page.keyboard.type('h')
+    expect(page.getByRole('button', { name: 'S' })).toHaveText('H')
+
+    await page.getByRole('button', { name: 'Share' }).click()
+    await page.getByRole('button', { name: 'Transfer' }).click()
+    await page.getByText('P/adJGUSlg+').click()
+    await page.getByRole('button', { name: 'Copy' }).click()
+
+    await page.getByText('new device', { exact: true }).click()
+    await page.locator('#immigration-code').click()
+    await page.getByText('Paste your migration code:Save').click()
+    await page
+      .getByLabel('Transfer your statistics')
+      .getByRole('button')
+      .first()
+      .click()
+
+    await page.getByLabel('Open Settings').click()
+    await page.getByLabel('Hard Mode').locator('div').click()
+    await page.getByLabel('Dark Mode').click()
+    await page.getByLabel('High Contrast Mode').click()
+    await page
+      .getByLabel('Settings', { exact: true })
+      .getByRole('button')
+      .click()
+
+    //  get window.dataLayer and check events
+    await page.waitForTimeout(300)
+    const dataLayer = await page.evaluate(() => window.dataLayer)
+    console.log('dataLayer', dataLayer)
+    const events = dataLayer
+      .filter((e) => !!e.event)
+      .map((event) => event.event)
+
+    expect(events).toEqual(['gtm.dom', 'gtm.scrollDepth', 'gtm.load'])
+
+    const gameEvents = dataLayer
+      .filter((e) => e[0] === 'event')
+      .map(
+        (event) =>
+          `${event[1]}: ${
+            event[2]?.achievement_id ||
+            event[2]?.achievement_id ||
+            event[2]?.level_name ||
+            event[2]?.level ||
+            event[2]?.method
+          }`
+      )
+    console.log('gameEvents', gameEvents)
+
+    expect(gameEvents).toEqual([
+      'unlock_achievement: open_shared_message',
+      'level_start: Cryptogram 794 hi',
+      'sign_up: Anonymous',
+      'login: Anonymous',
+      'unlock_achievement: click_alphabet_letter',
+      'unlock_achievement: make_incorrect_guess',
+      'unlock_achievement: make_correct_guess',
+      'unlock_achievement: make_correct_guess',
+      'level_up: 1',
+      'post_score: 1',
+      'level_end: Cryptogram 794 hi',
+      'share: Navigator Clipboard API',
+      'unlock_achievement: click_transfer_stats',
+      'unlock_achievement: exported_stats',
+      'unlock_achievement: open_settings',
+      'unlock_achievement: choose_dark_mode',
+      'unlock_achievement: choose_high_contrast',
+    ])
+  })
+})


### PR DESCRIPTION
for #71 

Examples of events from the analytics playright test i added

```
'unlock_achievement: open_shared_message',
'level_start: Cryptogram 794 hi',
'sign_up: Anonymous',
'login: Anonymous',
'unlock_achievement: click_alphabet_letter',
'unlock_achievement: make_incorrect_guess',
'unlock_achievement: make_correct_guess',
'unlock_achievement: make_correct_guess',
'level_up: 1',
'post_score: 1',
'level_end: Cryptogram 794 hi',
'share: Navigator Clipboard API',
'unlock_achievement: click_transfer_stats',
'unlock_achievement: exported_stats',
'unlock_achievement: open_settings',
'unlock_achievement: choose_dark_mode',
'unlock_achievement: choose_high_contrast',
```


Recommended events https://support.google.com/analytics/answer/9267735?sjid=18202014437832800737-NA

We recommend these events for games properties. Sending these events populates the [games reports](https://support.google.com/analytics/answer/9713967).

 DONE | Event | Trigger when a user...
-- | -- | --
 ⬜ |  earn_virtual_currency | earns virtual currency (coins, gems, tokens, etc.)
 ⬜ | join_group | joins a group
🟩 | level_end | completes a level in a game
🟩 | level_start | starts a new level in a game
🟩 | level_up | levels-up in the game
🟩 | post_score | posts their score
⬜ | select_content | selects content
⬜ | spend_virtual_currency | spends virtual currency (coins, gems, tokens, etc.)
🟩 | tutorial_begin | begins a tutorial during an on-boarding process
🟩 | tutorial_complete | completes a tutorial during an on-boarding process
🟩 | unlock_achievement | unlocks an achievement


DONE | Event | Trigger when a user...
-- | -- | --
⬜| ad_impression | sees an advertisement, for apps only
⬜| earn_virtual_currency | earns virtual currency (coins, gems, tokens, etc.)
⬜| generate_lead | submits a form or a request for information
⬜| join_group | joins a group
🟩  | login | logs in
⬜| purchase | completes a purchase
⬜| refund | receives a refund
⬜| search | searches your website or app
⬜| select_content | selects content on your website or app
🟩  | share | shares content from your website or app
🟩  | sign_up | signs up for an account on your website or app
⬜ | spend_virtual_currency | spends virtual currency (coins, gems, tokens, etc.)
🟩 | tutorial_begin | begins a tutorial during an on-boarding process
🟩 | tutorial_complete | completes a tutorial during an on-boarding process
