### PR TITLE
Mark level completed even if it was an archived game or message

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -331,6 +331,10 @@ function App() {
         }
       })
       if (areAllLettersGuessed) {
+        window.gtag('event', 'level_end', {
+          level_name: `Cryptogram ${solutionName}`,
+          success: true,
+        })
         debug('All the letters have been guessed', guesses)
         if (isLatestGame) {
           // TODO this is causing the stats to be multiples of page reloads
@@ -351,6 +355,10 @@ function App() {
           incorrectGuesses,
           MAX_CHALLENGES
         )
+        window.gtag('event', 'level_end', {
+          level_name: `Cryptogram ${solutionName}`,
+          success: false,
+        })
         if (isLatestGame) {
           setStats(
             addStatsForCompletedGame(

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -30,17 +30,9 @@ export const addStatsForCompletedGame = (
     // A fail situation
     stats.currentStreak = 0
     stats.gamesFailed += 1
-    window.gtag('event', 'level_end', {
-      level_name: `Cryptogram ${gameName}`,
-      success: false,
-    })
   } else {
     stats.winDistribution[count] += 1
     stats.currentStreak += 1
-    window.gtag('event', 'level_end', {
-      level_name: `Cryptogram ${gameName}`,
-      success: true,
-    })
 
     if (stats.bestStreak < stats.currentStreak) {
       stats.bestStreak = stats.currentStreak


### PR DESCRIPTION
As a game designer I want to know that the user has completed an archived game or a shared message 


Before 


the level-up was only recorded if it was todays game, which makes sense fo stats but not for making sure users are finishing games


<img width="2006" alt="Screenshot 2024-03-06 at 11 27 08 PM" src="https://github.com/cesine/fantastic-lamp/assets/196199/b23b679b-6d3a-41a3-8d64-7bf4c4f07e2a">


After

the level- up will be recorded on shared messages and archived games 

<img width="2009" alt="Screenshot 2024-03-06 at 11 28 42 PM" src="https://github.com/cesine/fantastic-lamp/assets/196199/64b6532f-67c3-4700-ad2b-b09c2aa4961c">

