### PR TITLE
Hide h4 since we arent using histogram

### DIFF
--- a/src/components/modals/StatsModal.tsx
+++ b/src/components/modals/StatsModal.tsx
@@ -80,9 +80,11 @@ export const StatsModal = ({
       handleClose={handleClose}
     >
       <StatBar gameStats={gameStats} />
-      <h4 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
-        {GUESS_DISTRIBUTION_TEXT}
-      </h4>
+      {showHistogram ? (
+        <h4 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
+          {GUESS_DISTRIBUTION_TEXT}
+        </h4>
+      ) : null}
       {showHistogram ? (
         <Histogram
           isLatestGame={isLatestGame}


### PR DESCRIPTION
Before

<img width="1153" alt="Screenshot 2024-03-09 at 10 30 50 PM" src="https://github.com/cesine/fantastic-lamp/assets/196199/f5341f2d-3e58-4303-8304-1f52b95d2d5e">

After

<img width="1188" alt="Screenshot 2024-03-09 at 10 32 07 PM" src="https://github.com/cesine/fantastic-lamp/assets/196199/456dc665-dc45-4b83-9611-9294294cca86">
