### PR TITLE
Fix hard mode no more hints

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -495,7 +495,7 @@ function App() {
         achievement_id: 'use_hint',
       })
     }
-    if (hintCount >= 10) {
+    if (hintCount >= (isHardMode ? MAX_HINTS : 10)) {
       window.gtag('event', 'unlock_achievement', {
         achievement_id: 'exhausted_hints',
       })


### PR DESCRIPTION
Steps to reproduce

1. click on hard mode
2. click on hints more than 3 times
3. observe that it never tells you why its not giving more hints


After

3. after 3 hints it will tell you that there are no more hints